### PR TITLE
Issue #139

### DIFF
--- a/R/csem_model.R
+++ b/R/csem_model.R
@@ -212,17 +212,17 @@ parseModel <- function(.model) {
       
       # For each structural equation: Get names of single constructs that are already
       # set to 1
-      z <- names(temp[i, names_constructs][temp[i, names_constructs] == 1])
-      
-      if(length(setdiff(x, z)) > 0) {
-        stop(paste0("The structural equation for `", i, "` contains interactions between constructs", 
-                    " that do not appear individually.\n",
-                    "This is almost certainly not a meaningful model."), call. = FALSE)
-      }
+      # z <- names(temp[i, names_constructs][temp[i, names_constructs] == 1])
+      # 
+      # if(length(setdiff(x, z)) > 0) {
+      #   stop(paste0("The structural equation for `", i, "` contains interactions between constructs", 
+      #               " that do not appear individually.\n",
+      #               "This is almost certainly not a meaningful model."), call. = FALSE)
+      # }
       
       # If x containes an interaction term, assign 1 to all elements in temp[i, ] whose
-      # column names match one or more of the elements/names of the splitted terms
-      temp[i, intersect(x, colnames(temp))] <- 1
+      # column name matches one or more of the elements/names of the splitted terms
+      # temp[i, intersect(x, colnames(temp))] <- 1
     }
     
     ## Return error if the structural model contains feedback loops


### PR DESCRIPTION
@FloSchuberth this version works if the constructs of the interaction term appear individually _in at least one_ structural equation. For example this would work:
`model <- "y ~ x1 + x2 + x3.x2; w ~ y + x3; ..."`
This is, even if `x3` is not part of the first equation.

However, if `x3` is not part of  **any** equation, estimation breaks. Take for example:
`model <- "y ~ x1 + x2 + x3.x2; w ~ y ..."`

The first instance where such a model would break is within the `calculateOuterWeightsPLS()` function. The reason being that now `model$structural` has one column (`x3`) that has only 0's. If we compute the matrix of inner weights `E` this matrix has also one column of zeros (again `x3`). Now if we want to compute the proxy_indicator correlation `E %*% W %*% .S` we get a matrix that doesnt have full column rank. Since some lines later we have to invert this matrix, this fails.

I guess the general question is: how to we treat `x3` in this case. To the model it is like `x3` doesnt even exist (not part of the nomological net). We just need it as a a helper to create `x3.x2`. 
But how do we get scores for `x3` when it is not part of the model in itself?