### PR TITLE
Issue438

### DIFF
--- a/R/csem_resample.R
+++ b/R/csem_resample.R
@@ -302,15 +302,17 @@ resampleData <- function(
             # shuffle data set
             y <- y[sample(1:nrow(y)), ]
             if(ceiling(nrow(data)/.cv_folds)*.cv_folds - nrow(data) < ceiling(nrow(data)/.cv_folds)){
-            suppressWarnings(
+              
+            #In case that warnings occur, the splitting of the data set might be changed  
+            #suppressWarnings(
               split(as.data.frame(y), rep(1:.cv_folds, 
                                           each = ceiling(nrow(y)/.cv_folds)))
-            )
+            #)
             }else{
-              suppressWarnings(
+              #suppressWarnings(
                 split(as.data.frame(y), rep(1:.cv_folds, 
                                             each = floor(nrow(y)/.cv_folds)))
-              ) 
+              #) 
             }
           }, future.seed = .seed)
         })

--- a/R/csem_resample.R
+++ b/R/csem_resample.R
@@ -276,6 +276,14 @@ resampleData <- function(
           "The following error occured in the `resampleData()` function:\n",
           "A minimum of 2 cross-validation folds required.")
       }
+      if((ceiling(nrow(data)/.cv_folds)*.cv_folds - nrow(data) >= ceiling(nrow(data)/.cv_folds))){
+        warning2(
+          "The following error occured in the `resampleData()` function:\n",
+          "The number of .cv_folds is not plausible for the given sample size.\n",
+          "Change .cv_folds such that \n",
+          "ceiling(nrow(data)/.cv_folds)*.cv_folds - nrow(data) <= ceiling(nrow(data)/.cv_folds)"
+        )
+      }
       # k-fold cross-validation (=draw k samples of equal size.).
       # Note the last sample may contain less observations if equal sized
       # samples are not possible
@@ -293,10 +301,17 @@ resampleData <- function(
           future.apply::future_lapply(1:.R, function(x) {
             # shuffle data set
             y <- y[sample(1:nrow(y)), ]
+            if(ceiling(nrow(data)/.cv_folds)*.cv_folds - nrow(data) < ceiling(nrow(data)/.cv_folds)){
             suppressWarnings(
               split(as.data.frame(y), rep(1:.cv_folds, 
                                           each = ceiling(nrow(y)/.cv_folds)))
             )
+            }else{
+              suppressWarnings(
+                split(as.data.frame(y), rep(1:.cv_folds, 
+                                            each = floor(nrow(y)/.cv_folds)))
+              ) 
+            }
           }, future.seed = .seed)
         })
       } else {
@@ -311,10 +326,17 @@ resampleData <- function(
         # shuffle data
         future.apply::future_lapply(1:.R, function(x) {
           data <- data[sample(1:nrow(data)), ]
+          if(ceiling(nrow(data)/.cv_folds)*.cv_folds - nrow(data) < ceiling(nrow(data)/.cv_folds)){
           suppressWarnings(
             split(as.data.frame(data), rep(1:.cv_folds, 
                                            each = ceiling(nrow(data)/.cv_folds)))
           )
+          }else{
+            suppressWarnings(
+              split(as.data.frame(data), rep(1:.cv_folds, 
+                                             each = floor(nrow(data)/.cv_folds)))
+            )
+          }
         }, future.seed = .seed)
       }
     } # END cross-validation


### PR DESCRIPTION
The inital split of the sample during cross-validation was suboptimal because it could create empty datasets. In case that empty datasets would be produced by the inital split, a different splitting is used instead. Moreover, we give a warning indicating that the chosen cv_folds is not plausible for the given sample size.