### PR TITLE
Check if `.Random.seed` is initialized restoring it in `on.exit()`

### DIFF
--- a/R/csem_resample.R
+++ b/R/csem_resample.R
@@ -216,11 +216,14 @@ resampleData <- function(
     }
   }
   
-  # Save old seed and restore on exit! This is important since users may have
+  # Save old seed (if it exists) and restore on exit!
+  # This is important since users may have
   # set a seed before, in which case the global seed would be
-  # overwritten if not explicitly restored
-  old_seed <- .Random.seed
-  on.exit({.Random.seed <<- old_seed})
+  # overwritten if not explicitly restored.
+  if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+    old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
+  }
   
   ## Create seed if not already set
   if(is.null(.seed)) {
@@ -578,12 +581,10 @@ resamplecSEMResults <- function(
   # Save old seed and restore on exit! This is important since users may have
   # set a seed before, in which case the global seed would be
   # overwritten if not explicitly restored
-  # Note (07.10.2020): for some tests performed by testthat .Random.seed is not 
-  #                   available. This is when it is not initialized. To initialize
-  #                   the .Random.seed object a random number is generated.
-  runif(1)
-  old_seed <- .Random.seed
-  on.exit({.Random.seed <<- old_seed})
+  if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+    old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
+  }
   
   ## Create seed if not already set
   if(is.null(.seed)) {

--- a/R/postestimate_test_MGD.R
+++ b/R/postestimate_test_MGD.R
@@ -593,11 +593,14 @@ testMGD <- function(
     # pb <- txtProgressBar(min = 0, max = .R_permutation, style = 3)
   }
   
-    # Save old seed and restore on exit! This is important since users may have
+    # Save old seed (if it exists) and restore on exit!
+    # This is important since users may have
     # set a seed before, in which case the global seed would be
-    # overwritten if not explicitly restored
-    old_seed <- .Random.seed
-    on.exit({.Random.seed <<- old_seed})
+    # overwritten if not explicitly restored.
+    if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+      old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+      on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
+    }
     
     ## Create seed if not already set
     if(is.null(.seed)) {

--- a/R/postestimate_test_MICOM.R
+++ b/R/postestimate_test_MICOM.R
@@ -171,11 +171,14 @@ testMICOM <- function(
     #   pb <- txtProgressBar(min = 0, max = .R, style = 3)
     # }
     
-    # Save old seed and restore on exit! This is important since users may have
+    # Save old seed (if it exists) and restore on exit!
+    # This is important since users may have
     # set a seed before, in which case the global seed would be
-    # overwritten if not explicitly restored
-    old_seed <- .Random.seed
-    on.exit({.Random.seed <<- old_seed})
+    # overwritten if not explicitly restored.
+    if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+      old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+      on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
+    }
     
     ## Create seed if not already set
     if(is.null(.seed)) {

--- a/R/postestimate_test_OMF.R
+++ b/R/postestimate_test_OMF.R
@@ -182,11 +182,14 @@ testOMF <- function(
   X_trans           <- X %*% S_half %*% Sig_half
   colnames(X_trans) <- colnames(X)
   
-  # Save old seed and restore on exit! This is important since users may have
+  # Save old seed (if it exists) and restore on exit!
+  # This is important since users may have
   # set a seed before, in which case the global seed would be
   # overwritten if not explicitly restored.
-  old_seed <- .Random.seed
-  on.exit({.Random.seed <<- old_seed})
+  if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+    old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
+  }
   
   ## Create seed if not already set
   if(is.null(.seed)) {


### PR DESCRIPTION
Changes addressing #626

Instead of unconditionally setting `old_seed <- .Random.seed` we first check if `.Random.seed` exists in the global environment.

Additionally, instead of using `old_seed <- .Random.seed`  and `.Random.seed <<- old_seed` we use `get()` and `assign()` instead, allowing us to get/set `.Random.seed` in the global environment directly, without relying on lexical scoping (which could break at some point if we ever define `.Random.seed` as a variable within the package). If `.Random.seed` does not exist, we do nothing (we could in theory try to remove `.Random.seed` from the global environment on exit instead...).

```r
if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
  old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
  on.exit(assign(".Random.seed", old_seed, envir = .GlobalEnv), add = TRUE)
}
```
I also made sure that we pass `add=TRUE` when using `on.exit()`, as it safely works with multiple calls to `on.exit()`. There was an existing bug caused by not passing `add=TRUE` in `R/csem_resample.R`

```r
oplan <- future::plan()
on.exit(future::plan(oplan), add = TRUE) # first on.exit() call
future::plan("sequential")
... # code between
old_seed <- .Random.seed
on.exit({.Random.seed <<- old_seed}) # second on.exit() call (overwriting the previous on.exit() call)
```
